### PR TITLE
Add authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,15 @@
+Flauto Authors
+===============
+
+* __[Hyo Chan Jang](https://github.com/hyochan)__
+
+    Author and maintainer of the original [`flutter_sound`](https://github.com/dooboolab/flutter_sound) package.
+
+* __[Salvatore Rago](https://github.com/salvatore373)__
+
+    Added some features to the [`flutter_sound`](https://github.com/dooboolab/flutter_sound) plug-in (e.g. the media controls on lock screen), restructured the code and the architecture of the package ([orinal PR](https://github.com/dooboolab/flutter_sound/pull/202)).
+
+
+* __[Larpoux](https://github.com/Larpoux)__
+
+    Used [Salvatore's](https://github.com/salvatore373) code to create the new [`flauto`](https://github.com/Canardoux/flauto) as a higher level module of [`flutter_sound`](https://github.com/dooboolab/flutter_sound) module.


### PR DESCRIPTION
Hi Larpoux,
I am Salvatore Rago. You might probably know me as salvatore373 for [my Github account](https://github.com/salvatore373/) and because of my collaboration to the flutter_sound Github project. Here is [my PR](https://github.com/dooboolab/flutter_sound/pull/202) where we both collaborated.

As you know, in that PR I worked a lot to add new features to the wonderful flutter_sound plugin, and I created a new version of the code. However, that PR was rejected.

I have recently seen that you have been working on a package called flauto, where you created a new version of flutter_sound including the features that I proposed in PR #202. I noticed that you used my code to include those features, and you used the same new code structure as well as the same new architecture that I proposed in my PR and in [my repository](https://github.com/salvatore373/flutter_sound/tree/lock-screen-controls2).
I'm really glad that someone appreciated my code so much to include it in their package, but I would be even more pleased to be added among the authors of the flauto package, since I am the author of a big and important part of the code, I am the author of the code structure and the architecture of your package, and I am the author of the idea of including the features that are the core of your repository.

In conclusion, I hope that in this situation you will show the same kindness and the same professionalism that you showed in the PR conversation, and I am sure that you will continue to be an example and to teach your experience to a young developer like me. I hope that we will continue to work together to flauto (where I still have a lot of updates to propose and a lot of help to give), to flutter_sound and to a lot of other projects.

Have a nice day